### PR TITLE
Remove duplicate DOMContentLoaded listeners

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -180,18 +180,6 @@ document.addEventListener("DOMContentLoaded", function () {
   setLanguage("en");
 });
 
-
-// Iniciar Typed en inglés por defecto al cargar la página
-document.addEventListener("DOMContentLoaded", function () {
-  setLanguage("en");
-});
-
-
-// Iniciar Typed en inglés por defecto al cargar la página
-document.addEventListener("DOMContentLoaded", function () {
-  setLanguage("en");
-});
-
 (function() {
   "use strict";
 


### PR DESCRIPTION
## Summary
- Ensure `setLanguage` only runs once by keeping a single DOMContentLoaded listener in `assets/js/main.js`.

## Testing
- `node - <<'NODE'
const fs=require('fs'),vm=require('vm');
let callCount=0;
const dummy=new Proxy(function(){},{get:()=>dummy,apply:()=>dummy});
const document={_listeners:{},addEventListener(event,handler){(this._listeners[event]=this._listeners[event]||[]).push(handler);},getElementById(){return dummy;},querySelector(){return dummy;},querySelectorAll(){return {forEach(){}};}};
const window={addEventListener(){},scrollY:0,scrollTo(){},location:{}};
global.document=document;
global.window=window;
global.Typed=dummy;
global.PureCounter=dummy;
global.GLightbox=dummy;
global.Waypoint=dummy;
global.AOS={init(){}};
global.Isotope=dummy;
global.imagesLoaded=(el,cb)=>cb();
global.Swiper=dummy;
global.getComputedStyle=()=>({scrollMarginTop:0});
vm.runInThisContext(fs.readFileSync('assets/js/main.js','utf8'));
global.setLanguage=function(){callCount++;};
document._listeners['DOMContentLoaded'].forEach(h=>h());
console.log('DOMContentLoaded listeners:',document._listeners['DOMContentLoaded'].length);
console.log('setLanguage called',callCount,'times');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6897414113d0832a9ae4c70c03fc2f28